### PR TITLE
Add Windows Sound System support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ A_DEBUG_FLAGS=
 OBJFILES = &
 	$(OUTD)/main.obj		$(OUTD)/sndisr.obj		$(OUTD)/ptrap.obj		$(OUTD)/linear.obj		$(OUTD)/pic.obj &
 	$(OUTD)/vsb.obj			$(OUTD)/vdma.obj		$(OUTD)/virq.obj		$(OUTD)/vmpu.obj		$(OUTD)/tsf.obj &
+        $(OUTD)/ad1848.obj             $(OUTD)/wss.obj &
 !ifndef NOFM
 	$(OUTD)/dbopl.obj		$(OUTD)/vopl3.obj &
 !endif
@@ -166,6 +167,8 @@ $(OUTD)/vioout.obj:    src\VIOOUT.ASM
 $(OUTD)/virq.obj:      src\VIRQ.C
 $(OUTD)/vmpu.obj:      src\VMPU.C
 $(OUTD)/vsb.obj:       src\VSB.C
+$(OUTD)/ad1848.obj:    src\AD1848.C
+$(OUTD)/wss.obj:       src\WSS.C
 !ifndef NOFM
 $(OUTD)/dbopl.obj:     src\DBOPL.CPP
 $(OUTD)/vopl3.obj:     src\VOPL3.CPP

--- a/djgpp.mak
+++ b/djgpp.mak
@@ -50,7 +50,8 @@ OBJFILES=\
         $(OUTD)/DMAIRQ.o        $(OUTD)/PCIBIOS.o       $(OUTD)/MEMORY.o       $(OUTD)/PHYSMEM.o        $(OUTD)/TIMER.o\
         $(OUTD)/SC_E1371.o      $(OUTD)/SC_ICH.o        $(OUTD)/SC_INTHD.o     $(OUTD)/SC_VIA82.o       $(OUTD)/SC_SBLIV.o      $(OUTD)/SC_SBL24.o\
         $(OUTD)/STACKIO.o       $(OUTD)/STACKISR.o      $(OUTD)/SBISR.o        $(OUTD)/INT31.o          $(OUTD)/RMWRAP.o        $(OUTD)/MIXER.o\
-        $(OUTD)/HAPI.o          $(OUTD)/DPRINTF.o       $(OUTD)/VIOOUT.o       $(OUTD)/DJDPMI.o         $(OUTD)/UNINST.o        $(OUTD)/FILEACC.o
+        $(OUTD)/HAPI.o          $(OUTD)/DPRINTF.o       $(OUTD)/VIOOUT.o       $(OUTD)/DJDPMI.o         $(OUTD)/UNINST.o        $(OUTD)/FILEACC.o\
+        $(OUTD)/AD1848.o        $(OUTD)/WSS.o
 
 INCLUDE_DIRS=src MPXPLAY
 SRC_DIRS=src MPXPLAY
@@ -143,11 +144,11 @@ $(OUTD)/DBOPL.o:    src/DBOPL.CPP   src/DBOPL.H
 	$(COMPILE.cpp.o)
 $(OUTD)/LINEAR.o:   src/LINEAR.C    src/LINEAR.H src/PLATFORM.H
 	$(COMPILE.c.o)
-$(OUTD)/MAIN.o:     src/MAIN.C      src/LINEAR.H src/PLATFORM.H src/PTRAP.H src/VOPL3.H src/PIC.H src/CONFIG.H src/VSB.H src/VDMA.H src/VIRQ.H src/AU.H src/VERSION.H
+$(OUTD)/MAIN.o:     src/MAIN.C      src/LINEAR.H src/PLATFORM.H src/PTRAP.H src/VOPL3.H src/PIC.H src/CONFIG.H src/VSB.H src/VDMA.H src/VIRQ.H src/AU.H src/VERSION.H src/WSS.H
 	$(COMPILE.c.o)
 $(OUTD)/PIC.o:      src/PIC.C       src/PIC.H src/PLATFORM.H src/PTRAP.H
 	$(COMPILE.c.o)
-$(OUTD)/PTRAP.o:    src/PTRAP.C     src/LINEAR.H src/PLATFORM.H src/PTRAP.H src/CONFIG.H
+$(OUTD)/PTRAP.o:    src/PTRAP.C     src/LINEAR.H src/PLATFORM.H src/PTRAP.H src/CONFIG.H src/WSS.H
 	$(COMPILE.c.o)
 $(OUTD)/SNDISR.o:   src/SNDISR.C    src/LINEAR.H src/PLATFORM.H src/VOPL3.H src/PIC.H src/CONFIG.H src/VSB.H src/VDMA.H src/VIRQ.H src/CTADPCM.H src/AU.H
 	$(COMPILE.c.o)

--- a/src/AD1848.C
+++ b/src/AD1848.C
@@ -1,0 +1,67 @@
+#include <string.h>
+#include "AD1848.H"
+
+void AD1848_Reset(AD1848 *ad)
+{
+    memset(ad, 0, sizeof(*ad));
+    ad->status = 0xcc;
+    ad->mce = 0x40;
+    ad->regs[0] = 0x00;
+    ad->regs[1] = 0x00;
+    ad->regs[2] = 0x80;
+    ad->regs[3] = 0x80;
+    ad->regs[4] = 0x80;
+    ad->regs[5] = 0x80;
+    ad->regs[6] = 0x80;
+    ad->regs[7] = 0x80;
+    ad->regs[8] = 0x00;
+    ad->regs[9] = 0x08;
+    ad->regs[10] = 0x00;
+    ad->regs[11] = 0x00;
+    ad->regs[12] = 0x0a;
+    ad->regs[13] = 0x00;
+    ad->regs[14] = 0x00;
+    ad->regs[15] = 0x00;
+}
+
+uint8_t AD1848_Read(AD1848 *ad, uint16_t port)
+{
+    switch(port & 3)
+    {
+        case 0:
+            return ad->index | ad->trd | ad->mce;
+        case 1:
+            return ad->regs[ad->index & 0x1F];
+        case 2:
+            return ad->status;
+    }
+    return 0xFF;
+}
+
+void AD1848_Write(AD1848 *ad, uint16_t port, uint8_t val)
+{
+    switch(port & 3)
+    {
+        case 0:
+            ad->index = val & 0x1F;
+            ad->trd   = val & 0x20;
+            ad->mce   = val & 0x40;
+            break;
+        case 1:
+            ad->regs[ad->index & 0x1F] = val;
+            break;
+        case 2:
+            ad->status &= ~0x01; /* acknowledge interrupt */
+            break;
+    }
+}
+
+void AD1848_SetDMA(AD1848 *ad, int dma)
+{
+    ad->dma = dma;
+}
+
+void AD1848_SetIRQ(AD1848 *ad, int irq)
+{
+    ad->irq = irq;
+}

--- a/src/AD1848.H
+++ b/src/AD1848.H
@@ -1,0 +1,23 @@
+#ifndef AD1848_EMU_H
+#define AD1848_EMU_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct {
+    uint8_t index;
+    uint8_t trd;
+    uint8_t mce;
+    uint8_t status;
+    int dma;
+    int irq;
+    uint8_t regs[32];
+} AD1848;
+
+void AD1848_Reset(AD1848 *ad);
+uint8_t AD1848_Read(AD1848 *ad, uint16_t port);
+void AD1848_Write(AD1848 *ad, uint16_t port, uint8_t val);
+void AD1848_SetDMA(AD1848 *ad, int dma);
+void AD1848_SetIRQ(AD1848 *ad, int irq);
+
+#endif // AD1848_EMU_H

--- a/src/MAIN.C
+++ b/src/MAIN.C
@@ -25,6 +25,7 @@
 #include "VSB.H"
 #include "SNDISR.H"
 #include "VMPU.H"
+#include "WSS.H"
 #include "VERSION.H"
 
 #include "AU.H"
@@ -466,6 +467,7 @@ int main(int argc, char* argv[])
 #endif
 
     VPIC_Init( AU_getirq( gm.hAU ) );
+    WSS_Reset();
 
 #ifdef NOFM
     gvars.opl3 = 0;
@@ -517,6 +519,9 @@ int main(int argc, char* argv[])
     if ( gvars.slowdown  )
         printf("Slowdown factor=%u\n", gvars.slowdown );
 #endif
+    printf("Windows Sound System at address 530, IRQ %d, DMA %d: %s\n",
+           WSS_GetIRQ(), WSS_GetDMA(),
+           WSS_IRQFree() ? "enabled" : "disabled");
     /* temp alloc a 64 kB chunk of memory. This will ensure that mallocs done while sound is playing won't
      * need another DPMI memory allocation. A dpmi memory allocation while another client is active will
      * result in problems, since that memory is released when that client exits.

--- a/src/PTRAP.C
+++ b/src/PTRAP.C
@@ -25,6 +25,7 @@
 #include "VDMA.H"
 #include "VIRQ.H"
 #include "VSB.H"
+#include "WSS.H"
 #include "HAPI.H"
 #if VMPU
 #include "VMPU.H"
@@ -57,7 +58,7 @@ extern void * copyrmcode( void *, int );
 void * dosheap;
 #endif
 
-static uint32_t traphdl[8+1] = {0}; /* hdpmi32i trap handles */
+static uint32_t traphdl[9+1] = {0}; /* hdpmi32i trap handles */
 
 
 struct HDPMIAPI_ENTRY HDPMIAPI_Entry; /* vendor API entry */
@@ -76,9 +77,11 @@ static const uint8_t ChannelPageMap[] = { 0x87, 0x83, 0x81, 0x82, -1, 0x8b, 0x89
 #define HDMA_PDT  5
 #define SB_PDT    6
 #define MPU_PDT   7
+#define WSS_PDT   8
 #else
 #define SB_PDT    5
 #define MPU_PDT   6
+#define WSS_PDT   7
 #endif
 
 static uint16_t PortTable[] = {
@@ -102,8 +105,11 @@ static uint16_t PortTable[] = {
 	0x22A, 0x22C,
 	0x22E, 0x22F | 0x8000,
 #if VMPU
-	0x330, 0x331 | 0x8000,
+        0x330, 0x331 | 0x8000,
 #endif
+        0x530, 0x531, 0x532, 0x533,
+        0x534, 0x535, 0x536, 0x537,
+        0x538 | 0x8000,
     0xffff
 };
 
@@ -129,14 +135,17 @@ static PORT_TRAP_HANDLER PortHandler[] = {
 	VSB_DSP_Read, VSB_DSP_Write,                /* 0x22A, 0x22C */
 	VSB_DSP_ReadStatus, VSB_DSP_ReadINT16BitACK, /* 0x22e, 0x22f */
 #if VMPU
-	VMPU_MPU, VMPU_MPU,
+        VMPU_MPU, VMPU_MPU,
 #endif
+        WSS_Port, WSS_Port, WSS_Port, WSS_Port,
+        WSS_Port, WSS_Port, WSS_Port, WSS_Port,
+        WSS_Port,
 };
 
 static uint16_t PortState[countof(PortHandler)];
 
 /* hdpmi is restricted to 8 port ranges */
-static int portranges[8+1];
+static int portranges[9+1];
 
 /* real-mode port trap handler;
  * called by SwitchStackIOrmcb().

--- a/src/WSS.C
+++ b/src/WSS.C
@@ -60,5 +60,14 @@ int WSS_GetIRQ(void)
 bool WSS_IRQFree(void)
 {
     uint16_t mask = PIC_GetIRQMask();
-    return PIC_IS_IRQ_MASKED(mask, WSS_IRQ);
+    return !(mask & (1 << WSS_IRQ));
+}
+
+uint32_t WSS_Port(uint32_t port, uint32_t val, uint32_t out)
+{
+    if(out) {
+        WSS_WritePort((uint16_t)port, (uint8_t)val);
+        return val;
+    }
+    return (val & ~0xFF) | WSS_ReadPort((uint16_t)port);
 }

--- a/src/WSS.C
+++ b/src/WSS.C
@@ -1,0 +1,64 @@
+#include <string.h>
+#include "WSS.H"
+#include "PIC.H"
+
+static const int WSS_DMA_Map[4] = {0, 0, 1, 3};
+static const int WSS_IRQ_Map[8] = {5, 7, 9, 10, 11, 12, 14, 15};
+
+static uint8_t WSS_Config;
+static int WSS_DMA;
+static int WSS_IRQ;
+static AD1848 WSS_AD;
+
+void WSS_Reset(void)
+{
+    AD1848_Reset(&WSS_AD);
+    WSS_Config = 0;
+    WSS_DMA = 3; /* PCem defaults to DMA 3 */
+    WSS_IRQ = 7; /* PCem defaults to IRQ 7 */
+    AD1848_SetDMA(&WSS_AD, WSS_DMA);
+    AD1848_SetIRQ(&WSS_AD, WSS_IRQ);
+}
+
+uint8_t WSS_ReadPort(uint16_t port)
+{
+    if(port >= 0x530 && port <= 0x537)
+        return AD1848_Read(&WSS_AD, port);
+    if(port == 0x538)
+        return WSS_Config;
+    return 0xFF;
+}
+
+void WSS_WritePort(uint16_t port, uint8_t value)
+{
+    if(port >= 0x530 && port <= 0x537)
+    {
+        AD1848_Write(&WSS_AD, port, value);
+        return;
+    }
+    if(port == 0x538)
+    {
+        WSS_Config = value;
+        WSS_DMA = WSS_DMA_Map[value & 3];
+        WSS_IRQ = WSS_IRQ_Map[(value >> 3) & 7];
+        AD1848_SetDMA(&WSS_AD, WSS_DMA);
+        AD1848_SetIRQ(&WSS_AD, WSS_IRQ);
+        return;
+    }
+}
+
+int WSS_GetDMA(void)
+{
+    return WSS_DMA;
+}
+
+int WSS_GetIRQ(void)
+{
+    return WSS_IRQ;
+}
+
+bool WSS_IRQFree(void)
+{
+    uint16_t mask = PIC_GetIRQMask();
+    return PIC_IS_IRQ_MASKED(mask, WSS_IRQ);
+}

--- a/src/WSS.H
+++ b/src/WSS.H
@@ -1,0 +1,16 @@
+#ifndef WSS_EMU_H
+#define WSS_EMU_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "PLATFORM.H"
+#include "AD1848.H"
+
+void WSS_Reset(void);
+uint8_t WSS_ReadPort(uint16_t port);
+void WSS_WritePort(uint16_t port, uint8_t value);
+int WSS_GetDMA(void);
+int WSS_GetIRQ(void);
+bool WSS_IRQFree(void);
+
+#endif // WSS_EMU_H

--- a/src/WSS.H
+++ b/src/WSS.H
@@ -12,5 +12,6 @@ void WSS_WritePort(uint16_t port, uint8_t value);
 int WSS_GetDMA(void);
 int WSS_GetIRQ(void);
 bool WSS_IRQFree(void);
+uint32_t WSS_Port(uint32_t port, uint32_t val, uint32_t out);
 
 #endif // WSS_EMU_H


### PR DESCRIPTION
## Summary
- add AD1848 emulation helpers
- implement WSS device emulation
- show WSS availability in the main program
- build WSS sources via Makefile

## Testing
- `wmake -h` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e6df575c832c915d3e086ad40d91